### PR TITLE
Add test coverage analysis

### DIFF
--- a/+Tests/runTestForPackage.m
+++ b/+Tests/runTestForPackage.m
@@ -1,0 +1,32 @@
+function result = runTestForPackage(package)
+
+    import matlab.unittest.TestSuite
+    import matlab.unittest.TestRunner
+    import matlab.unittest.plugins.CodeCoveragePlugin
+    import matlab.unittest.plugins.codecoverage.ProfileReport
+    import matlab.unittest.plugins.codecoverage.CoberturaFormat
+
+    if ischar(package)
+        package = cellstr(package);
+    elseif iscellstr(package)
+    else
+        error('Tests:runTestForPackage:invalidInputType',...
+            '''package'' must either be a char or cellstr.')
+    end
+    
+    nPackages       = numel(package);
+    
+    for pp = 1:nPackages
+        testPath        = ['Tests.',package{pp}];
+
+        suite           = TestSuite.fromPackage(testPath,...
+                            'IncludingSubpackages',	true);
+        runner          = TestRunner.withTextOutput;
+
+        plugin          = CodeCoveragePlugin.forPackage(package{pp},...
+                            'Producing',            ProfileReport);
+
+        runner.addPlugin(plugin)
+        result  = runner.run(suite);
+    end
+end

--- a/+Tests/runTestsLocally.m
+++ b/+Tests/runTestsLocally.m
@@ -1,8 +1,34 @@
 clear
 
 import matlab.unittest.TestSuite
+import matlab.unittest.TestRunner
+import matlab.unittest.plugins.CodeCoveragePlugin
+import matlab.unittest.plugins.codecoverage.ProfileReport
+import matlab.unittest.plugins.codecoverage.CoberturaFormat
 
-tests   = TestSuite.fromPackage('Tests',...
-          	'IncludingSubpackages', true);
-result  = run(tests);
+ignorePackages    = {'Tests'};
+
+% Determine packages
+tmp         = dir();
+names       = {tmp.name}';
+packages    = regexp(names,'^\+([A-Za-z]+$)','tokens');
+packages    = cat(1,packages{:});
+packages    = cat(1,packages{:});
+packages    = packages(~ismember(packages,ignorePackages));
+    
+tests       = TestSuite.fromPackage('Tests',...
+                'IncludingSubpackages', true);
+            
+            
+coveragePath    = [tests(1).BaseFolder,'/+Tests/coverage/'];
+runner          = TestRunner.withTextOutput;
+% pluginA         = CodeCoveragePlugin.forPackage(packages,...
+%                     'Producing',            ProfileReport);
+% pluginB         = CodeCoveragePlugin.forPackage(packages,...
+%                     'Producing',            CoberturaFormat([coveragePath,'cobertura.xml']));
+        
+% runner.addPlugin(pluginA)
+% runner.addPlugin(pluginB)
+result  = runner.run(tests);
+
 display(result);

--- a/+Tests/runTestsRemotely.m
+++ b/+Tests/runTestsRemotely.m
@@ -1,10 +1,19 @@
 
 import matlab.unittest.TestSuite
+import matlab.unittest.TestRunner
+import matlab.unittest.plugins.CodeCoveragePlugin
+import matlab.unittest.plugins.codecoverage.CoberturaFormat
 
 try
     tests   = TestSuite.fromPackage('Tests',...
                 'IncludingSubpackages', true);
-    result  = run(tests);
+    runner	= TestRunner.withTextOutput;
+    plugin 	= CodeCoveragePlugin.forPackage(package{pp},...
+            	'Producing',            'cobertura.xml');
+        
+	runner.addPlugin(plugin)
+    result  = runner.run(tests);
+    
     display(result);
 catch ME
     disp(getReport(ME,'extended'));

--- a/+Tests/runTestsRemotely.m
+++ b/+Tests/runTestsRemotely.m
@@ -4,19 +4,50 @@ import matlab.unittest.TestRunner
 import matlab.unittest.plugins.CodeCoveragePlugin
 import matlab.unittest.plugins.codecoverage.CoberturaFormat
 
+ignorePackages    = {'Tests'};
+
 try
+    % Determine packages
+    tmp         = dir();
+    names       = {tmp.name}';
+    packages    = regexp(names,'^\+([A-Za-z]+$)','tokens');
+    packages    = cat(1,packages{:});
+    packages    = cat(1,packages{:});
+    packages    = packages(~ismember(packages,ignorePackages));
+
     tests   = TestSuite.fromPackage('Tests',...
                 'IncludingSubpackages', true);
     runner	= TestRunner.withTextOutput;
-    plugin 	= CodeCoveragePlugin.forPackage(package{pp},...
-            	'Producing',            'cobertura.xml');
-        
-	runner.addPlugin(plugin)
+    coberturaFilename = 'cobertura.xml';
+    plugin 	= CodeCoveragePlugin.forPackage(packages,...
+                'Producing',            CoberturaFormat(coberturaFilename));
+
+    runner.addPlugin(plugin)
     result  = runner.run(tests);
     
     display(result);
+    pwd
+    ls
+    fixCoberturaFile(coberturaFilename)
 catch ME
     disp(getReport(ME,'extended'));
     exit(1);
 end
 exit(any([result.Failed]));
+
+function fixCoberturaFile(filename)
+
+    fileId      = fopen(filename,'r+');
+    rawText     = textscan(fileId,'%s','EndOfLine','','Delimiter','');
+    lengthBefore    = numel(rawText{1}{:});
+    fixedText       = strrep(rawText{1},'/</source>','</source>');
+    lengthAfter     = numel(fixedText{1});
+    lengthDiff      = lengthAfter - lengthBefore;
+    if lengthDiff ~= -1
+        warning('Tests:runTestsRemotely:fixCoberturaFile:invalidFileChange',...
+            'Invalid change of characters detected. Detected %i, expected -1.',lengthDiff)
+    end
+    frewind(fileId);
+    fprintf(fileId,'%s',fixedText{1});
+    fclose(fileId);
+end

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.m~
 *.trial.m
-CoverageResults*.xml
 
 +DataKit/+DespikeKit/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.m~
 *.trial.m
+CoverageResults*.xml
 
 +DataKit/+DespikeKit/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,20 @@
 language: matlab
+env:
+  global:
+    - CC_TEST_REPORTER_ID=b709f07598662ca3a4688ae6b684b094d599e28dc92358526b47be5756593d33
+    - CC_TEST_REPORTER=$TRAVIS_BUILD_DIR/cc-test-reporter
 matlab:
+  - R2020a  # Earliest supported MATLAB release on Travis CI
   - latest  # Default MATLAB release on Travis CI
+
+before_script:
+  # download code climate test reporter, make it executable & run the before build
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 > $CC_TEST_REPORTER
+  - chmod +x $CC_TEST_REPORTER
+  - $CC_TEST_REPORTER before-build
 script: matlab -batch 'Tests.runTestsRemotely'
+after_script:
+  # run the code climate after build
+  #- $CC_TEST_REPORTER format-coverage $TRAVIS_BUILD_DIR/cobertura.xml --input-type cobertura --output $TRAVIS_BUILD_DIR/codeclimate.json -d
+  #- if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then $CC_TEST_REPORTER upload-coverage --input $TRAVIS_BUILD_DIR/codeclimate.json --id "$CC_TEST_REPORTER_ID" -d; fi
+  - $CC_TEST_REPORTER after-build --id $CC_TEST_REPORTER_ID --exit-code $TRAVIS_TEST_RESULT -d


### PR DESCRIPTION
Add test coverage analysis via Code Climate.

During the CI build, the executed MATLAB script (`runTestsRemotely.m`) outputs a cobertura.xml file with the coverage results of the MATLAB profiler. This is then converted and uploaded to Code Climate by the Code Climate [test reporter](https://github.com/codeclimate/test-reporter).

Closes #23 