### PR TITLE
gearType as enumeration class

### DIFF
--- a/+GearKit/@gearDeployment/applyMeasuringDeviceConfiguration.m
+++ b/+GearKit/@gearDeployment/applyMeasuringDeviceConfiguration.m
@@ -1,6 +1,6 @@
 function obj = applyMeasuringDeviceConfiguration(obj)
 
-    fName = [obj.dataFolderInfo.rootFolder,'/',char(obj.cruise),'_',obj.gearType,'_measuringDevicesConfiguration.xlsx'];
+    fName = [obj.dataFolderInfo.rootFolder,'/',char(obj.cruise),'_',char(obj.gearType),'_measuringDevicesConfiguration.xlsx'];
     try
         tbl = DataKit.importTableFile(fName);
     catch ME
@@ -17,7 +17,7 @@ function obj = applyMeasuringDeviceConfiguration(obj)
 	for row = 1:size(tbl,1)
         % find relevant variables
         [poolIdx,variableIdx] = obj.data.findVariable('VariableMeasuringDevice.Type',char(tbl{row,'Type'}),'VariableMeasuringDevice.SerialNumber',char(tbl{row,'SerialNumber'}),'-and','Variable.Id',tbl{row,'Variable'});
-        
+
         % set new measurment device metadata
         for vv = 1:numel(variableIdx)
             obj.data = obj.data.setMeasuringDeviceProperty(poolIdx(vv),variableIdx(vv),'Type',char(tbl{row,'TypeNew'}));

--- a/+GearKit/@gearDeployment/assignMeasuringDeviceMountingData.m
+++ b/+GearKit/@gearDeployment/assignMeasuringDeviceMountingData.m
@@ -2,12 +2,12 @@ function assignMeasuringDeviceMountingData(obj)
 % ASSIGNMEASURINGDEVICEMOUNTINGDATA
 
     import DataKit.importTableFile
-    
+
 	if obj.debugger.debugLevel >= 'Info'
-        fprintf('INFO: assigning %s measuring device(s) mounting locations... \n',obj.gearType);
+        fprintf('INFO: assigning %s measuring device(s) mounting locations... \n',char(obj.gearType));
 	end
-    
-    measuringDeviceDataFile  = [obj.dataFolderInfo.rootFolder,'/',char(obj.cruise),'_',obj.gearType,'_measuringDevices.xlsx'];
+
+    measuringDeviceDataFile  = [obj.dataFolderInfo.rootFolder,'/',char(obj.cruise),'_',char(obj.gearType),'_measuringDevices.xlsx'];
     try
         measuringDeviceData	= importTableFile(measuringDeviceDataFile);
         measuringDeviceData	= measuringDeviceData(measuringDeviceData{:,'Cruise'} == obj.cruise & ...
@@ -21,7 +21,7 @@ function assignMeasuringDeviceMountingData(obj)
                 rethrow(ME);
         end
     end
-    
+
     maskMatches = obj.data.Index{:,'MeasuringDevice'} == cellstr(measuringDeviceData{:,{'Type','SerialNumber'}});
     for md = 1:size(obj.data.Index,1)
         dp  = obj.data.Index{md,'DataPool'};
@@ -35,9 +35,9 @@ function assignMeasuringDeviceMountingData(obj)
                 'There is no mounting data defined in\n\t%s\nfor\n\t%s\n',measuringDeviceDataFile,strjoin({obj.sensors(md).id,obj.sensors(md).serialNumber},' '))
         end
     end
-    
-    
+
+
 	if obj.debugger.debugLevel >= 'Info'
-        fprintf('INFO: assigning %s measuring device(s) mounting locations... done\n',obj.gearType);
+        fprintf('INFO: assigning %s measuring device(s) mounting locations... done\n',char(obj.gearType));
 	end
 end

--- a/+GearKit/@gearDeployment/calibrateMeasuringDevices.m
+++ b/+GearKit/@gearDeployment/calibrateMeasuringDevices.m
@@ -3,7 +3,7 @@ function calibrateMeasuringDevices(obj)
     import GearKit.*
 
 	if obj.debugger.debugLevel >= 'Info'
-        fprintf('INFO: calibrating %s measuring device(s)... \n',obj.gearType);
+        fprintf('INFO: calibrating %s measuring device(s)... \n',char(obj.gearType));
 	end
 
     obj.calibration{:,'CalibrationTime'} = mean(obj.calibration{:,{'CalibrationStart','CalibrationEnd'}},2);
@@ -120,6 +120,6 @@ function calibrateMeasuringDevices(obj)
     end
 
 	if obj.debugger.debugLevel >= 'Info'
-        fprintf('INFO: calibrating %s measuring device(s)... done\n',obj.gearType);
+        fprintf('INFO: calibrating %s measuring device(s)... done\n',char(obj.gearType));
 	end
 end

--- a/+GearKit/@gearDeployment/gearDeployment.m
+++ b/+GearKit/@gearDeployment/gearDeployment.m
@@ -32,7 +32,8 @@ classdef gearDeployment < handle
 
 	properties
         data DataKit.dataPool = DataKit.dataPool()
-        gearType = char.empty % Type of gear
+        HardwareConfiguration GearKit.hardwareConfiguration
+        gearType GearKit.gearType = GearKit.gearType.undefined % Type of gear
         cruise = categorical.empty % Cruise id of the deployment
         gear = categorical.empty % Gear id of the deployment
         station = categorical.empty % Station id of the deployment
@@ -53,10 +54,6 @@ classdef gearDeployment < handle
     properties (Dependent)
         variables % List of variables available for this deployment
         gearId % Id string that uniquely identifies a gearDeploment
-    end
-    properties (Hidden, Access = private, Constant)
-        validGearTypes = {'BIGO','EC'} % List of valid gear types
-        validFileExtensions = {'.bigo','.ec'}
     end
     properties (Hidden)
         debugger DebuggerKit.Debugger % Debugging object
@@ -79,7 +76,7 @@ classdef gearDeployment < handle
                                     'DebugLevel',       debugLevel);
 
             obj.gearType        = gearType;
-            
+
             if isempty(path)
                 return
             end

--- a/+GearKit/@gearDeployment/getGearDeploymentMetadata.m
+++ b/+GearKit/@gearDeployment/getGearDeploymentMetadata.m
@@ -2,22 +2,22 @@ function getGearDeploymentMetadata(obj,pathName)
 % GETGEARDEPLOYMENTMETADATA
 
     import DataKit.importTableFile
-    
+
 	if obj.debugger.debugLevel >= 'Info'
-        fprintf('INFO: extracting %s deployment metadata... \n',obj.gearType);
+        fprintf('INFO: extracting %s deployment metadata... \n',char(obj.gearType));
 	end
-    
+
     % support empty initializeation of gearDeployment subclasses
     if isempty(pathName)
         return
     end
-    
+
     [~,obj.dataFolderInfo.gearName,~]  	= fileparts(pathName);
     obj.dataFolderInfo.dataFolder       = pathName;
-    tmpRootFolder                       = strsplit(pathName,'/');           
+    tmpRootFolder                       = strsplit(pathName,'/');
     obj.dataFolderInfo.rootFolder       = strjoin(tmpRootFolder(1:end - 2),'/');
-    
-    ids	= regexp(pathName,['(?<cruise>[A-Z]+\d+)_',obj.gearType,'_data(_)?(?<version>v\d+)?/(?<gear>',obj.gearType,'.+)$'],'names');
+
+    ids	= regexp(pathName,['(?<cruise>[A-Z]+\d+)_',char(obj.gearType),'_data(_)?(?<version>v\d+)?/(?<gear>',char(obj.gearType),'.+)$'],'names');
 
     obj.dataVersion = ids.version;
     obj.cruise      = categorical({ids.cruise});
@@ -28,10 +28,10 @@ function getGearDeploymentMetadata(obj,pathName)
             obj.gear    = categorical({ids.gear});
         otherwise
             error('Dingi:GearKit:GearDeployment:getGearDeploymentMetadata:undefinedGearType',...
-                'The gear type ''%s'' is not defined yet. Valid gear types are:\n\t%s.',obj.gearType,strjoin(obj.validGearTypes,', '))
+                'The gear type ''%s'' is not defined yet. Valid gear types are:\n\t%s.',char(obj.gearType),strjoin(GearKit.gearType.listMembers,', '))
     end
-    
-    deploymentMetadataFile  = [obj.dataFolderInfo.rootFolder,'/',char(obj.cruise),'_',obj.gearType,'_deployments.xlsx'];
+
+    deploymentMetadataFile  = [obj.dataFolderInfo.rootFolder,'/',char(obj.cruise),'_',char(obj.gearType),'_deployments.xlsx'];
     try
         deploymentMetadata     	= importTableFile(deploymentMetadataFile);
         deploymentMetadata      = deploymentMetadata(deploymentMetadata{:,'Cruise'} == obj.cruise & ...
@@ -58,8 +58,8 @@ function getGearDeploymentMetadata(obj,pathName)
                 rethrow(ME);
         end
     end
-    
+
 	if obj.debugger.debugLevel >= 'Info'
-        fprintf('INFO: extracting %s deployment metadata... done\n',obj.gearType);
+        fprintf('INFO: extracting %s deployment metadata... done\n',char(obj.gearType));
 	end
 end

--- a/+GearKit/@gearDeployment/loadobj.m
+++ b/+GearKit/@gearDeployment/loadobj.m
@@ -1,5 +1,5 @@
 function obj = loadobj(s)
-    
+
     switch s.gearType
         case 'BIGO'
             obj         = GearKit.bigoDeployment();
@@ -9,18 +9,18 @@ function obj = loadobj(s)
             metadata	= eval('?GearKit.ecDeployment');
         otherwise
             error('Dingi:GearKit:gearDeployment:loadobj:invalidGearType',...
-                'Invalid or unknown gearType ''%s''.',s.gearType)
+                'Invalid or unknown gearType ''%s''.',char(s.gearType))
     end
-    
+
     propertyNames   = {metadata.PropertyList.Name}';
     needsLoading    = find(~any(cat(2,cat(1,metadata.PropertyList.Transient),...
                                 cat(1,metadata.PropertyList.Constant),...
-                                cat(1,metadata.PropertyList.Dependent)),2));    
-    
+                                cat(1,metadata.PropertyList.Dependent)),2));
+
     for pp = 1:numel(needsLoading)
         obj.(propertyNames{needsLoading(pp)}) = s.(propertyNames{needsLoading(pp)});
     end
-    
+
     currentVersion  = getToolboxVersion();
     savedVersion    = s.toolboxVersion;
     deltaVersion    = compareSemanticVersion(currentVersion,savedVersion);
@@ -29,10 +29,10 @@ function obj = loadobj(s)
     elseif deltaVersion == 1
         % currentVersion > savedVersion
         warning('Dingi:GearKit:gearDeployment:loadobj:olderSavedVersion',...
-            'The %s deployment was saved with an older toolbox version (%s) than the current one (%s).',obj.gearType,savedVersion,currentVersion)
+            'The %s deployment was saved with an older toolbox version (%s) than the current one (%s).',char(obj.gearType),savedVersion,currentVersion)
     elseif deltaVersion == -1
         % currentVersion < savedVersion
         warning('Dingi:GearKit:gearDeployment:loadobj:newerSavedVersion',...
-            'The %s deployment was saved with a newer toolbox version (%s) than the current one (%s).',obj.gearType,savedVersion,currentVersion)
+            'The %s deployment was saved with a newer toolbox version (%s) than the current one (%s).',char(obj.gearType),savedVersion,currentVersion)
     end
 end

--- a/+GearKit/@gearDeployment/readCalibrationData.m
+++ b/+GearKit/@gearDeployment/readCalibrationData.m
@@ -8,7 +8,7 @@ function readCalibrationData(obj)
         return
     end
     
-    path            = [obj.dataFolderInfo.rootFolder,'/',char(obj.cruise),'_',obj.gearType,'_measuringDevicesCalibration.xlsx'];
+    path            = [obj.dataFolderInfo.rootFolder,'/',char(obj.cruise),'_',char(obj.gearType),'_measuringDevicesCalibration.xlsx'];
     tmp             = importTableFile(path);
     obj.calibration = tmp(all(tmp{:,{'Cruise','Gear'}} == [obj.cruise,obj.gear],2),:);
 end

--- a/+GearKit/@gearDeployment/save.m
+++ b/+GearKit/@gearDeployment/save.m
@@ -6,7 +6,7 @@ function filenames = save(objIn,filename,varargin)
     end
     
     nGearDeployments    = numel(objIn);
-    gearDeploymentExt   = objIn(1).validFileExtensions{strcmp(objIn(1).gearType,objIn(1).validGearTypes)};
+    gearDeploymentExt   = objIn(1).gearType.FileExtension;
     if ~strcmp(ext,gearDeploymentExt)
         warning('Dingi:GearKit:gearDeployment:save:invalidFileExtension',...
             'The provided file extension ''%s'' was changed to ''%s''',ext,gearDeploymentExt);

--- a/+GearKit/@gearType/fromProperty.m
+++ b/+GearKit/@gearType/fromProperty.m
@@ -1,0 +1,8 @@
+function obj = fromProperty(propertyname,value)
+
+    import DataKit.enum.core_fromProperty
+    
+    classname = mfilename('class');
+    
+    obj = core_fromProperty(classname,propertyname,value);
+end

--- a/+GearKit/@gearType/gearType.m
+++ b/+GearKit/@gearType/gearType.m
@@ -1,0 +1,25 @@
+classdef gearType < DataKit.enum
+    enumeration
+        %            Name                           Abbreviation    File Extension
+        undefined   ('',                            '',             '')
+        BIGO        ('Biogeochemical Observatory',  'BIGO',         '.bigo')
+        EC          ('Eddy Correlation Lander',     'ECL',          '.ec')
+    end
+    properties (SetAccess = 'immutable')
+        Name char
+        Abbreviation char
+        FileExtension char
+    end
+    methods
+        function obj = gearType(name,abbreviation,fileExtension,varargin)
+            obj.Name            = name;
+            obj.Abbreviation    = abbreviation;
+            obj.FileExtension	= fileExtension;
+        end
+    end
+    methods (Static)
+        L = listMembers()
+        obj = fromProperty(propertyname,value)
+        [tf,info] = validate(propertyname,value)
+    end
+end

--- a/+GearKit/@gearType/listMembers.m
+++ b/+GearKit/@gearType/listMembers.m
@@ -1,0 +1,7 @@
+function L = listMembers()
+    
+    import DataKit.enum.core_listMembers
+    
+    classname   = mfilename('class');
+    L           = core_listMembers(classname);
+end

--- a/+GearKit/@gearType/validate.m
+++ b/+GearKit/@gearType/validate.m
@@ -1,0 +1,8 @@
+function [tf,info] = validate(propertyname,value)
+
+    import DataKit.enum.core_validate
+    
+    classname = mfilename('class');
+    
+    [tf,info] = core_validate(classname,propertyname,value);
+end


### PR DESCRIPTION
This PR implements the `GearKit.gearDeployment` property `GearType` as an enumeration class instead of a char. See #49 for details.

Closes #49.