### PR TITLE
Automatically import multiple analytical sample spreadsheets that match a pattern

### DIFF
--- a/+DataKit/ressources/validMethods.xlsx
+++ b/+DataKit/ressources/validMethods.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93b48420aa3e40dd574fa3125a8377f1e66b4c009aa2fa97e5a4fcf3b7a43d8b
-size 9035
+oid sha256:7cde850b6c6094b041cc3e9f8bf9da30491e845308f36c607865174e73ab62d2
+size 9038

--- a/+GearKit/@gearDeployment/gearDeployment.m
+++ b/+GearKit/@gearDeployment/gearDeployment.m
@@ -146,4 +146,7 @@ classdef gearDeployment < matlab.mixin.SetGet
     methods (Abstract)
         runAnalysis(obj)
     end
+    methods (Access = protected, Static)
+        tbl = readAnalyticalSampleFiles(folder,expression)
+    end
 end

--- a/+GearKit/@gearDeployment/readAnalyticalSampleFiles.m
+++ b/+GearKit/@gearDeployment/readAnalyticalSampleFiles.m
@@ -1,0 +1,94 @@
+function tbl = readAnalyticalSampleFiles(folder,expression)
+% readAnalyticalSampleFiles  Reads and merges analytical sample files
+%   READANALYTICALSAMPLEFILES finds all analytical sample files in a folder,
+%     reads them and concatenates them vertically.
+%
+%   Syntax
+%     tbl = READANALYTICALSAMPLEFILES(folder,expression)
+%
+%   Description
+%     tbl = READANALYTICALSAMPLEFILES(folder,expression) finds all files in
+%       directory folder that match the regular expression
+%       '<expression>_analyticalSamples.*\.xlsx$' reads and concatenates them.
+%
+%   Example(s)
+%     tbl = READANALYTICALSAMPLEFILES('~/data','AL570_BIGO') will match
+%     '~/data/AL570_BIGO_analyticalSamples.xlsx' and also
+%     '~/data/AL570_BIGO_analyticalSamples_DIC.xlsx', etc.
+%
+%
+%   Input Arguments
+%     folder - path to folder
+%       char row vector
+%         The absolute or relative path to the folder in which to look for
+%         analytcial sample files.
+%
+%     expression - regular expression to filter files
+%       char row vector
+%         A valid regular expression to filter the files found in folder with.
+%         Files are filtered with the regular expression
+%         '<expression>_analyticalSamples.*\.xlsx$'.
+%
+%
+%   Output Arguments
+%     tbl - output table
+%       table
+%         The output table holding the concatenated data of all matching files.
+%
+%
+%   Name-Value Pair Arguments
+%
+%
+%   See also DATAKIT.IMPORTTABLEFILE, REGEXP
+%
+%   Copyright (c) 2022-2022 David Clemens (dclemens@geomar.de)
+%
+
+    import DataKit.importTableFile
+    import DebuggerKit.Debugger.printDebugMessage
+    
+    expression  = [expression,'_analyticalSamples.*\.xlsx$'];
+    fileList    = struct2table(dir(folder));
+    fileMask    = ~cellfun(@isempty,regexp(fileList{:,'name'},expression));
+    fileList    = fileList(fileMask,:);
+    nFiles      = sum(fileMask);
+    
+    if nFiles == 0
+        expression = strrep(expression,'\','\\'); % Replace escape character to be aple to work with cprintf
+        printDebugMessage('Dingi:GearKit:gearDeployment:readAnalyticalSampleFiles:ColumnMismatch','Warning',...
+            'No analytical samples file matching expression ''%s'' found in folder ''%s''.',expression,folder)
+    end
+    
+    tbl = table();
+    for ff = 1:nFiles
+        % Read new data
+        try
+            filename    = [fileList{ff,'folder'}{:},filesep,fileList{ff,'name'}{:}];
+            tblNew      = importTableFile(filename);
+        catch ME
+            switch ME.identifier
+                case 'MATLAB:xlsread:FileNotFound'
+                    printDebugMessage('Dingi:GearKit:gearDeployment:readAnalyticalSampleFiles:ColumnMismatch','Error',...
+                        'No analytical samples file with name ''%s'' found.',filename)
+                otherwise
+                    rethrow(ME)
+            end
+        end
+        
+        % Append new data
+        try
+            tbl = cat(1,tbl,tblNew);
+        catch ME
+            switch ME.identifier
+                case 'MATLAB:table:vertcat:SizeMismatch'
+                    printDebugMessage('Dingi:GearKit:gearDeployment:readAnalyticalSampleFiles:ColumnMismatch','Error',...
+                        'File ''%s'' has a mismatching number of columns for the analytical samples table. It is not appended.',filename)
+                case 'MATLAB:table:vertcat:UnequalVarNames'
+                    printDebugMessage('Dingi:GearKit:gearDeployment:readAnalyticalSampleFiles:ColumnMismatch','Error',...
+                        'File ''%s'' has the wrong column names for the analytical samples table. It is not appended.',filename)
+                otherwise
+                    rethrow(ME)
+            end
+        end
+    end
+end

--- a/+GearKit/@gearDeployment/readAnalyticalSamples.m
+++ b/+GearKit/@gearDeployment/readAnalyticalSamples.m
@@ -1,111 +1,103 @@
 function readAnalyticalSamples(obj)
 % READANALYTICALSAMPLES
-
-    import DataKit.importTableFile
     import DebuggerKit.Debugger.printDebugMessage
+    import GearKit.gearDeployment.readAnalyticalSampleFiles
 
+    % Read the analytical sample data, if available
     printDebugMessage('Info','Reading %s analytical sample(s) data...',char(obj.gearType))
 
-    try
-        filename    = [obj.dataFolderInfo.rootFolder,'/',char(obj.cruise),'_',char(obj.gearType),'_analyticalSamples.xlsx'];
-        tbl         = importTableFile(filename);
-
-        if isempty(tbl)
-            % no analytical data found
-            return
-        end
-        mask        = all(tbl{:,{'Cruise','Gear'}} == [obj.cruise,obj.gear],2);
-
-        % append time data
-        tbl     = tbl(mask,:);
-        tbl     = outerjoin(tbl,obj.protocol,...
-                                    'Keys',             {'Subgear','SampleId'},...
-                                    'MergeKeys',        true,...
-                                    'RightVariables',   {'Time','TimeRelative'},...
-                                    'Type',             'left');
-
-        uMeasuringDevices   = unique(tbl(:,{'MeasuringDeviceType','Subgear'}),'rows');
-        nuMeasuringDevices  = size(uMeasuringDevices,1);
-        for mdt = 1:nuMeasuringDevices
-            
-            printDebugMessage('Verbose','Reading analytical data for measuring device %u of %u: %s %s ...',mdt,nuMeasuringDevices,char(uMeasuringDevices{mdt,'MeasuringDeviceType'}),char(uMeasuringDevices{mdt,'Subgear'}))
+    folder      = obj.dataFolderInfo.rootFolder;
+    expression  = ['^',char(obj.cruise),'_',char(obj.gearType)];
+    tbl         = readAnalyticalSampleFiles(folder,expression);
     
-            maskTbl     = all(tbl{:,{'MeasuringDeviceType','Subgear'}} == uMeasuringDevices{mdt,:},2);
-            maskTblInd 	= find(maskTbl);
-            if sum(maskTbl) == 0
-                continue
-            end
-            subs    = [];
-            [uRows,indepidx,subs(:,1)]	= unique(cellstr(tbl{maskTbl,{'SampleId'}}));
-            [uCols,~,subs(:,2)]         = unique(tbl{maskTbl,{'ParameterId'}});
+    if isempty(tbl)
+        % no analytical data found
+        return
+    end
+    mask        = all(tbl{:,{'Cruise','Gear'}} == [obj.cruise,obj.gear],2);
 
-            switch uMeasuringDevices{mdt,'MeasuringDeviceType'}
-                case 'BigoPushCore'
-                    data                = tbl{maskTblInd(indepidx),'Depth'};
-                    variables           = {'Depth'};
-                    variableOrigin      = {0};
-                    worldDomain         = GearKit.worldDomain.Sediment;
-                case {'BigoSyringeSampler','BigoCapillarySampler'}
-                    data                = seconds(tbl{maskTblInd(indepidx),'TimeRelative'});
-                    variables           = {'Time'};
-                    maskProtocol1       = obj.protocol{:,'MeasuringDeviceType'} == char(uMeasuringDevices{mdt,{'MeasuringDeviceType'}}) & ...
-                                          obj.protocol{:,'Subgear'} == uMeasuringDevices{mdt,'Subgear'};
-                    controlUnit         = obj.protocol{find(maskProtocol1,1),'ControlUnit'};
-                    maskExperimentStart	= all(obj.protocol{:,{'Subgear','SampleId','Event'}} == {char(controlUnit),'System','Experiment Start'},2);
-                    if sum(maskExperimentStart) ~= 1
-                        error('Dingi:GearKit:gearDeployment:readAnalyticalSamples:invalidExperimentStart',...
-                            'There is no or too many experiment start events found for %s.',cat(2,char(obj.cruise),' ',char(obj.gear),' ',char(uMeasuringDevices{mdt,'Subgear'})))
-                    end
-                    variableOrigin      = {obj.protocol{maskExperimentStart,'Time'}};
-                    worldDomain         = GearKit.worldDomain.BenthicWaterColumn;
-                case 'BigoManualSampling'
-                    maskProtocol1       = obj.protocol{:,'Subgear'} == uMeasuringDevices{mdt,'Subgear'};
-                    controlUnit         = obj.protocol{find(maskProtocol1,1),'ControlUnit'};
-                    maskExperimentStart	= all(obj.protocol{:,{'Subgear','SampleId','Event'}} == {char(controlUnit),'System','Experiment Start'},2);
-                    if sum(maskExperimentStart) ~= 1
-                        error('Dingi:GearKit:gearDeployment:readAnalyticalSamples:invalidExperimentStart',...
-                            'There is no or too many experiment start events found for %s.',cat(2,char(obj.cruise),' ',char(obj.gear),' ',char(uMeasuringDevices{mdt,'Subgear'})))
-                    end
-                    variableOrigin      = {obj.protocol{maskExperimentStart,'Time'}};
-                    variables           = {'Time'};
-                    data                = seconds(obj.timeRecovery - variableOrigin{:});
-                    worldDomain         = GearKit.worldDomain.BenthicWaterColumn;                    
-                case 'BigoNiskinBottle'
-                    variables           = {'Time'};
-                    maskExperimentStart	= all(obj.protocol{:,{'SampleId','Event'}} == {'System','Experiment Start'},2);
-                    variableOrigin      = {mean(obj.protocol{maskExperimentStart,'Time'})};
-                    data                = repmat(seconds(obj.timeRecovery - variableOrigin{1}),numel(indepidx),1);
-                    worldDomain         = GearKit.worldDomain.BenthicWaterColumn;
-                otherwise
-                    error('Dingi:GearKit:gearDeployment:readAnalyticalSamples:measuringDeviceTypeNotImplemented',...
-                        'Reading analytical sample(s) for measuring device type ''%s'' is not implemented.',char(uMeasuringDevices{mdt,'MeasuringDeviceType'}))
-            end
-            data            = cat(2,data,accumarray(subs,tbl{maskTbl,{'Value'}},[numel(uRows),numel(uCols)],@nanmean,NaN));
-            variables       = cat(2,variables,cellstr(DataKit.Metadata.variable.fromProperty('Id',uCols)'));
-            variableType    = cat(2,{'Independent'},repmat({'Dependent'},1,size(data,2) - 1));
+    % append time data
+    tbl     = tbl(mask,:);
+    tbl     = outerjoin(tbl,obj.protocol,...
+                                'Keys',             {'Subgear','SampleId'},...
+                                'MergeKeys',        true,...
+                                'RightVariables',   {'Time','TimeRelative'},...
+                                'Type',             'left');
 
-           	measuringDevice                     = GearKit.measuringDevice();
-            measuringDevice.Type                = char(uMeasuringDevices{mdt,'MeasuringDeviceType'});
-            measuringDevice.SerialNumber        = char(uMeasuringDevices{mdt,'Subgear'});
-            measuringDevice.MountingLocation    = char(uMeasuringDevices{mdt,'Subgear'});
-            measuringDevice.WorldDomain         = worldDomain;
-            measuringDevice.DeviceDomain        = GearKit.deviceDomain.fromProperty('Abbreviation',char(uMeasuringDevices{mdt,'Subgear'}));
+    uMeasuringDevices   = unique(tbl(:,{'MeasuringDeviceType','Subgear'}),'rows');
+    nuMeasuringDevices  = size(uMeasuringDevices,1);
+    for mdt = 1:nuMeasuringDevices
 
-            variableOrigin          = cat(2,variableOrigin,repmat({0},1,size(data,2) - 1));
-            variableMeasuringDevice	= repmat(measuringDevice,1,size(data,2));
+        printDebugMessage('Verbose','Reading analytical data for measuring device %u of %u: %s %s ...',mdt,nuMeasuringDevices,char(uMeasuringDevices{mdt,'MeasuringDeviceType'}),char(uMeasuringDevices{mdt,'Subgear'}))
 
-            obj.data.addVariable(variables,data,...
-                'VariableType',             variableType,...
-                'VariableOrigin',           variableOrigin,...
-                'VariableMeasuringDevice',	variableMeasuringDevice);
+        maskTbl     = all(tbl{:,{'MeasuringDeviceType','Subgear'}} == uMeasuringDevices{mdt,:},2);
+        maskTblInd 	= find(maskTbl);
+        if sum(maskTbl) == 0
+            continue
         end
-    catch ME
-        switch ME.identifier
-            case 'MATLAB:xlsread:FileNotFound'
-                printDebugMessage('Info','No file with name ''%s'' found',filename)
+        subs    = [];
+        [uRows,indepidx,subs(:,1)]	= unique(cellstr(tbl{maskTbl,{'SampleId'}}));
+        [uCols,~,subs(:,2)]         = unique(tbl{maskTbl,{'ParameterId'}});
+
+        switch uMeasuringDevices{mdt,'MeasuringDeviceType'}
+            case 'BigoPushCore'
+                data                = tbl{maskTblInd(indepidx),'Depth'};
+                variables           = {'Depth'};
+                variableOrigin      = {0};
+                worldDomain         = GearKit.worldDomain.Sediment;
+            case {'BigoSyringeSampler','BigoCapillarySampler'}
+                data                = seconds(tbl{maskTblInd(indepidx),'TimeRelative'});
+                variables           = {'Time'};
+                maskProtocol1       = obj.protocol{:,'MeasuringDeviceType'} == char(uMeasuringDevices{mdt,{'MeasuringDeviceType'}}) & ...
+                                      obj.protocol{:,'Subgear'} == uMeasuringDevices{mdt,'Subgear'};
+                controlUnit         = obj.protocol{find(maskProtocol1,1),'ControlUnit'};
+                maskExperimentStart	= all(obj.protocol{:,{'Subgear','SampleId','Event'}} == {char(controlUnit),'System','Experiment Start'},2);
+                if sum(maskExperimentStart) ~= 1
+                    error('Dingi:GearKit:gearDeployment:readAnalyticalSamples:invalidExperimentStart',...
+                        'There is no or too many experiment start events found for %s.',cat(2,char(obj.cruise),' ',char(obj.gear),' ',char(uMeasuringDevices{mdt,'Subgear'})))
+                end
+                variableOrigin      = {obj.protocol{maskExperimentStart,'Time'}};
+                worldDomain         = GearKit.worldDomain.BenthicWaterColumn;
+            case 'BigoManualSampling'
+                maskProtocol1       = obj.protocol{:,'Subgear'} == uMeasuringDevices{mdt,'Subgear'};
+                controlUnit         = obj.protocol{find(maskProtocol1,1),'ControlUnit'};
+                maskExperimentStart	= all(obj.protocol{:,{'Subgear','SampleId','Event'}} == {char(controlUnit),'System','Experiment Start'},2);
+                if sum(maskExperimentStart) ~= 1
+                    error('Dingi:GearKit:gearDeployment:readAnalyticalSamples:invalidExperimentStart',...
+                        'There is no or too many experiment start events found for %s.',cat(2,char(obj.cruise),' ',char(obj.gear),' ',char(uMeasuringDevices{mdt,'Subgear'})))
+                end
+                variableOrigin      = {obj.protocol{maskExperimentStart,'Time'}};
+                variables           = {'Time'};
+                data                = seconds(obj.timeRecovery - variableOrigin{:});
+                worldDomain         = GearKit.worldDomain.BenthicWaterColumn;                    
+            case 'BigoNiskinBottle'
+                variables           = {'Time'};
+                maskExperimentStart	= all(obj.protocol{:,{'SampleId','Event'}} == {'System','Experiment Start'},2);
+                variableOrigin      = {mean(obj.protocol{maskExperimentStart,'Time'})};
+                data                = repmat(seconds(obj.timeRecovery - variableOrigin{1}),numel(indepidx),1);
+                worldDomain         = GearKit.worldDomain.BenthicWaterColumn;
             otherwise
-                rethrow(ME)
+                error('Dingi:GearKit:gearDeployment:readAnalyticalSamples:measuringDeviceTypeNotImplemented',...
+                    'Reading analytical sample(s) for measuring device type ''%s'' is not implemented.',char(uMeasuringDevices{mdt,'MeasuringDeviceType'}))
         end
+        data            = cat(2,data,accumarray(subs,tbl{maskTbl,{'Value'}},[numel(uRows),numel(uCols)],@nanmean,NaN));
+        variables       = cat(2,variables,cellstr(DataKit.Metadata.variable.fromProperty('Id',uCols)'));
+        variableType    = cat(2,{'Independent'},repmat({'Dependent'},1,size(data,2) - 1));
+
+        measuringDevice                     = GearKit.measuringDevice();
+        measuringDevice.Type                = char(uMeasuringDevices{mdt,'MeasuringDeviceType'});
+        measuringDevice.SerialNumber        = char(uMeasuringDevices{mdt,'Subgear'});
+        measuringDevice.MountingLocation    = char(uMeasuringDevices{mdt,'Subgear'});
+        measuringDevice.WorldDomain         = worldDomain;
+        measuringDevice.DeviceDomain        = GearKit.deviceDomain.fromProperty('Abbreviation',char(uMeasuringDevices{mdt,'Subgear'}));
+
+        variableOrigin          = cat(2,variableOrigin,repmat({0},1,size(data,2) - 1));
+        variableMeasuringDevice	= repmat(measuringDevice,1,size(data,2));
+
+        obj.data.addVariable(variables,data,...
+            'VariableType',             variableType,...
+            'VariableOrigin',           variableOrigin,...
+            'VariableMeasuringDevice',	variableMeasuringDevice);
     end
 
     printDebugMessage('Info','Reading %s analytical sample(s) data... done',char(obj.gearType))

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Ignore temporary MATLAB files
+# Ignore temporary files
 *.m~
+~$*.xlsx
 
 # Ignore trial MATLAB files
 *.trial.m


### PR DESCRIPTION
Multiple analytical sample tables that are found in the data folder are now all imported on instance creation. This allows easier automated creation of analytical sample tables (e.g. for AlkalinityAnalyis or DICAnalysis).

For example the files `AL570_BIGO_analyticalSamples_DIC.xlsx` and `AL570_BIGO_analyticalSamples.xlsx` will both be imported for any BIGO deployment that was on cruise AL570.