### PR TITLE
Fix bug in `DataKit.bitflag.cat`

### DIFF
--- a/+DataKit/@bitflag/cat.m
+++ b/+DataKit/@bitflag/cat.m
@@ -51,15 +51,23 @@ function obj = cat(dim,varargin)
 %   Copyright (c) 2022-2023 David Clemens (dclemens@geomar.de)
 %
 
+    % Remove empty inputs
+    varargin = varargin(~cellfun(@isempty,varargin));
+    
+    % Check if all inputs are bitflags
     assert(all(cellfun(@(a) isa(a,'DataKit.bitflag'),varargin)),...
         'DataKit.bitflag:cat:TypeError',...
         'All inputs need to be of type DataKit.bitflag.')
+    
+    % Check if all inputs are of the same enumeration class name
     enumerationClassNames = cellfun(@(a) a.EnumerationClassName,varargin,'un',0);
     assert(numel(unique(enumerationClassNames)) == 1,...
         'DataKit:bitflag:cat:EnumerationClassMissmatch',...
         'The enumeration class names have to match.')
     
+    % Concatenate the bitmasks
     bitsC   = cat@DataKit.bitmask(dim,varargin{:});
     
+    % Construct a new bitflag instance
     obj     = DataKit.bitflag(varargin{1}.EnumerationClassName,bitsC.Bits);    
 end


### PR DESCRIPTION
The assertion failed if one or more inputs were empty.